### PR TITLE
Documents templates: General Dispute, Credit Report Dispute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package.zip
 .serverless
 node_modules
 coverage
+.DS_Store

--- a/src/documents/CreditReportDispute.js
+++ b/src/documents/CreditReportDispute.js
@@ -6,7 +6,7 @@ import PDFEngine from "../engines/PDFEngine";
 class CreditReportDispute extends Document implements DocumentGenerator {
   engine = PDFEngine;
   slug = "credit-report-dispute";
-  templates = [`${this.slug}/0.hbs`];
+  templates = [`${this.slug}/0.hbs`, `${this.slug}/1.hbs`];
   version = "v1";
 }
 

--- a/src/documents/__tests__/CreditReportDispute.spec.js
+++ b/src/documents/__tests__/CreditReportDispute.spec.js
@@ -32,7 +32,7 @@ const pathToPDFfolder = path.join(__dirname, "../../../pdf");
 const DocumentHandler = CreditReportDispute;
 
 // NOTE: CI is not able to run this since it relies on Chromium instance
-describe("generateFiles", () => {
+describe.skip("generateFiles", () => {
   let browser;
 
   beforeAll(() => {

--- a/src/documents/__tests__/CreditReportDispute.spec.js
+++ b/src/documents/__tests__/CreditReportDispute.spec.js
@@ -10,6 +10,10 @@ const fakeData = {
 };
 
 const fullData = {
+  agencies: [
+    { address: [faker.address.streetAddress(), faker.address.streetAddress()] },
+    { address: [faker.address.streetAddress()] },
+  ],
   creditors: [faker.company.companyName(), faker.company.companyName()],
   date: faker.date.recent(),
   user: {
@@ -67,6 +71,9 @@ describe("generateFiles", () => {
     expect(files.length).toEqual(DocumentHandler.templates.length);
     expect(
       readFiles.filter(readFileName => readFileName === files[0].fileName)
+    ).toHaveLength(1);
+    expect(
+      readFiles.filter(readFileName => readFileName === files[1].fileName)
     ).toHaveLength(1);
   });
 });

--- a/src/documents/__tests__/CreditReportDispute.spec.js
+++ b/src/documents/__tests__/CreditReportDispute.spec.js
@@ -1,0 +1,72 @@
+import CreditReportDispute from "../CreditReportDispute";
+import faker from "faker";
+import fs from "fs";
+import { getBrowser } from "../../setup";
+import path from "path";
+
+const fakeData = {
+  disputeId: faker.random.uuid(),
+  userId: faker.random.uuid(),
+};
+
+const fullData = {
+  creditors: [faker.company.companyName(), faker.company.companyName()],
+  date: faker.date.recent(),
+  user: {
+    address: faker.address.streetAddress(),
+    address2: faker.address.secondaryAddress(),
+    dob: faker.date.past(),
+    email: faker.internet.email(),
+    id: fakeData.userId,
+    name: faker.name.findName(),
+    phoneNumber: faker.phone.phoneNumber(),
+    ssn: faker.random.number(),
+  },
+};
+
+const pathToPDFfolder = path.join(__dirname, "../../../pdf");
+const DocumentHandler = CreditReportDispute;
+
+// NOTE: CI is not able to run this since it relies on Chromium instance
+describe("generateFiles", () => {
+  let browser;
+
+  beforeAll(() => {
+    // A place to store the created PDFs while development
+    const dir = pathToPDFfolder;
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
+    browser = getBrowser();
+  });
+
+  beforeEach(() => {
+    fs.readdirSync(pathToPDFfolder).forEach(f =>
+      fs.unlinkSync(path.join(pathToPDFfolder, f))
+    );
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it("creates a file for each template on the document", async () => {
+    const files = await DocumentHandler.generateFiles(fullData);
+
+    // simulate side effect after process files
+    await Promise.all(
+      files.map(async ({ fileName, file }) => {
+        const pathToFile = `pdf/${fileName}`;
+        await file.toFile(pathToFile);
+      })
+    );
+    const readFiles = fs.readdirSync(pathToPDFfolder);
+
+    expect(files.length).toEqual(DocumentHandler.templates.length);
+    expect(
+      readFiles.filter(readFileName => readFileName === files[0].fileName)
+    ).toHaveLength(1);
+  });
+});

--- a/src/documents/__tests__/GeneralDispute.spec.js
+++ b/src/documents/__tests__/GeneralDispute.spec.js
@@ -27,7 +27,7 @@ const pathToPDFfolder = path.join(__dirname, "../../../pdf");
 const DocumentHandler = GeneralDispute;
 
 // NOTE: CI is not able to run this since it relies on Chromium instance
-describe("generateFiles", () => {
+describe.skip("generateFiles", () => {
   let browser;
 
   beforeAll(() => {

--- a/src/documents/__tests__/GeneralDispute.spec.js
+++ b/src/documents/__tests__/GeneralDispute.spec.js
@@ -1,0 +1,71 @@
+import faker from "faker";
+import fs from "fs";
+import GeneralDispute from "../GeneralDispute";
+import { getBrowser } from "../../setup";
+import path from "path";
+
+const fakeData = {
+  disputeId: faker.random.uuid(),
+  userId: faker.random.uuid(),
+};
+
+const fullData = {
+  agency: {
+    address1: faker.address.streetAddress(),
+    address2: faker.address.secondaryAddress(),
+    name: faker.company.companyName(),
+  },
+  user: {
+    address1: faker.address.streetAddress(),
+    address2: faker.address.secondaryAddress(),
+    id: fakeData.userId,
+    name: faker.name.findName(),
+  },
+};
+
+const pathToPDFfolder = path.join(__dirname, "../../../pdf");
+const DocumentHandler = GeneralDispute;
+
+// NOTE: CI is not able to run this since it relies on Chromium instance
+describe("generateFiles", () => {
+  let browser;
+
+  beforeAll(() => {
+    // A place to store the created PDFs while development
+    const dir = pathToPDFfolder;
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
+
+    browser = getBrowser();
+  });
+
+  beforeEach(() => {
+    fs.readdirSync(pathToPDFfolder).forEach(f =>
+      fs.unlinkSync(path.join(pathToPDFfolder, f))
+    );
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it("creates a file for each template on the document", async () => {
+    const files = await DocumentHandler.generateFiles(fullData);
+
+    // simulate side effect after process files
+    await Promise.all(
+      files.map(async ({ fileName, file }) => {
+        const pathToFile = `pdf/${fileName}`;
+        await file.toFile(pathToFile);
+      })
+    );
+    const readFiles = fs.readdirSync(pathToPDFfolder);
+
+    expect(files.length).toEqual(DocumentHandler.templates.length);
+    expect(
+      readFiles.filter(readFileName => readFileName === files[0].fileName)
+    ).toHaveLength(1);
+  });
+});

--- a/src/templates/credit-report-dispute/0.hbs
+++ b/src/templates/credit-report-dispute/0.hbs
@@ -1,7 +1,47 @@
-<h1>Credit Report Dispute</h1>
-<div class="header">
-    <h1>{{dispute.id}}</h1>
-</div>
-<div class="body">
-    <p>{{user.name}}</p>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <style>
+    #letter {
+      font-size: 10pt;
+      font-family: "Times New Roman", Times, serif;
+      text-align: justify;
+    }
+
+    .user-info>p {
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="letter">
+    <p>Date: <strong>{{date}}</strong></p>
+    <p>Re: Credit Report Errors</p>
+    <p>Dear Sir or Madam:</p>
+    <p>I have discovered inaccurate information on my credit reports. The reports are in my name, <strong>{{user.name}}</strong>.</p>
+    {{#if creditors}}<p>The creditors or collectors that are reporting me for debts that I do not owe include: <strong>{{creditors}}</strong>.</p>{{/if}}
+    <p>Please find enclosed a copy of the portions of the credit reports containing the mistaken data.</p>
+    <p>
+      Please investigate all of the above matters with the creditors in question and send me written confirmation that
+      the items have been removed. In addition, please make this letter a permanent part of my credit record.
+    </p>
+    <p>
+      According to the Fair Credit Reporting Act, it is your duty to investigate my dispute within a 30 day period
+      after receiving this request. If you find that the disputed items are inaccurate or that they cannot be verified, it is your duty to remove the items from my report.
+      Please send me a corrected copy of my report. If you have any questions about my request or any of the credit
+      information in question, please do not hesitate to call me at <strong>{{user.phoneNumber}}</strong>.
+    </p>
+    <p>Thank you for your prompt attention to my request.</p><br />
+    <div class="user-info">
+      <p>{{user.name}}</p>
+      <p>{{user.address}}</p>
+      <p>{{user.address2}}</p><br />
+      <p>Date of Birth: {{user.dob}}</p>
+      <p>Social Security Number: {{user.ssn}}</p>
+      <p>Email: {{user.email}}</p>
+      <p>Phone: {{user.phoneNumber}}</p>
+    </div>
+  </div>
+</body>

--- a/src/templates/credit-report-dispute/1.hbs
+++ b/src/templates/credit-report-dispute/1.hbs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <style>
+    #letter {
+      font-size: 10pt;
+      font-family: "Times New Roman", Times, serif;
+      text-align: justify;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    p.address {
+      margin: 0 0 0 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="letter">
+    <p>Send to:</p><br />
+    {{#each agencies as |item key|}}
+        <p class="address">{{item.address}}</p>
+    {{/each}}
+  </div>
+</body>

--- a/src/templates/general-dispute/0.hbs
+++ b/src/templates/general-dispute/0.hbs
@@ -1,7 +1,76 @@
-<h1>General Dispute</h1>
-<div class="header">
-    <h1>{{dispute.id}}</h1>
-</div>
-<div class="body">
-    <p>{{user.name}}</p>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <style>
+    #letter {
+      font-size: 10pt;
+      font-family: 'Times';
+      font-variant-ligatures: common-ligatures;
+    }
+
+    div>p:nth-child(1) {
+      margin-top: 10px;
+      margin-bottom: 10px;
+    }
+
+    div>p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+
+    ul {
+      padding-left: 1em;
+      margin-top: 0;
+    }
+
+    .mb0 {
+      margin-bottom: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="letter">
+    <header>
+      <div>
+        <p>{{user.name}}</p>
+        <p>{{user.address1}}</p>
+        <p>{{user.address2}}</p><br>
+        <p>{{agency.name}}</p>
+        <p>{{agency.address1}}</p>
+        <p>{{agency.address2}}</p><br>
+        <p>{{date}}</p>
+      </div>
+    </header>
+    <section id="body">
+      <p>Dear {{agency.name}},</p>
+      <p>I am writing in response to your letter dated {{letterDateFormated}}, (copy enclosed) because I am disputing
+        the alleged debt.</p>
+      <p>If you are the original creditor, please send a copy of the contract or promissory note that I signed to
+        initiate this debt.</p>
+      <p class="mb0">If you are not the original creditor, please send the following documentation as required by the
+        FDCPA 15 U.S.C:
+        <ul>
+          <li>name of original creditor or entity from whom you purchased this debt;</li>
+          <li>proof that you own the debt or are authorized to collect this debt on behalf of the current owner;</li>
+          <li>proof of the amount owed;</li>
+          <li>proof that the debt was actually incurred by me with respect to the original creditor;</li>
+          <li>a copy of any judgment (if applicable);</li>
+          <li>proof that you are licensed to collect debts in my state.</li>
+        </ul>
+      </p>
+      <p>If you cannot produce the above materials, please send confirmation that you will no longer be collecting on
+        the above debt as well as confirmation that you have removed any negative the tradeline from my credit report.
+      </p>
+      <p>Reporting information that you know to be inaccurate, or failing to report information correctly, violates the
+        FDCPA and the Fair Credit Reporting Act. I will report any violations to the CFPB as well as to state
+        authorities and the FTC.</p>
+      <p>Aside from verifying the debt, <u>do not contact me about this debt</u>. The FDCPA requires that you honor this
+        request.</p>
+      <p>Sincerely,<br>{{user.name}}</p>
+    </section>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
**What:** Migrate templates from the previous platform for Documents related to:
- General Dispute
- Credit Report Dispute

**Why:** related to https://github.com/debtcollective/disputes/issues/36

**How:**
1. Use https://pughtml.com/ paste the previous pug template
2. From the output, HTML translate it to handlebars
3. Add test suite to replicate the process with fake data

**Note:**
The type of files like the one in the image is created by the test suite in order to be able to check the final output and iterate on the creation of the document itself.

![image](https://user-images.githubusercontent.com/1425162/60542479-54418e80-9d14-11e9-9022-af2360d17aef.png)
